### PR TITLE
refactor(nix): consistent substituter/trusted-substituter config

### DIFF
--- a/darwinModules/nixelium.nix
+++ b/darwinModules/nixelium.nix
@@ -21,7 +21,18 @@ let
     "https://bytecodealliance.cachix.org"
     "https://crane.cachix.org"
     "https://nix-community.cachix.org"
+    "https://install.determinate.systems"
     "https://cache.flakehub.com"
+  ];
+
+  trusted-public-keys = [
+    "rvolosatovs.cachix.org-1:eRYUO4OXTSmpDFWu4wX3/X08MsP01baqGKi9GsoAmQ8="
+    "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
+    "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+    "bytecodealliance.cachix.org-1:0SBgh//n2n0heh0sDFhTm+ZKBRy2sInakzFGfzN531Y="
+    "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk="
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM="
   ];
 
   username = "rvolosatovs";
@@ -112,15 +123,7 @@ in
       determinateNix.customSettings.require-sigs = true;
       determinateNix.customSettings.substituters = substituters;
       determinateNix.customSettings.use-case-hack = false;
-      determinateNix.customSettings.trusted-public-keys = [
-        "rvolosatovs.cachix.org-1:eRYUO4OXTSmpDFWu4wX3/X08MsP01baqGKi9GsoAmQ8="
-        "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
-        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-        "bytecodealliance.cachix.org-1:0SBgh//n2n0heh0sDFhTm+ZKBRy2sInakzFGfzN531Y="
-        "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk="
-        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM="
-      ];
+      determinateNix.customSettings.trusted-public-keys = trusted-public-keys;
       determinateNix.customSettings.trusted-substituters = substituters;
       determinateNix.customSettings.trusted-users = with config.users; [
         "@admin"

--- a/nixosModules/nixelium.nix
+++ b/nixosModules/nixelium.nix
@@ -20,6 +20,27 @@ let
   email = "rvolosatovs@riseup.net";
   username = "rvolosatovs";
 
+  substituters = [
+    "https://rvolosatovs.cachix.org"
+    "https://nixify.cachix.org"
+    "https://bytecodealliance.cachix.org"
+    "https://crane.cachix.org"
+    "https://nix-community.cachix.org"
+  ]
+  ++ optionals config.determinate.enable [
+    "https://install.determinate.systems"
+    "https://cache.flakehub.com"
+  ];
+
+  trusted-public-keys = [
+    "rvolosatovs.cachix.org-1:eRYUO4OXTSmpDFWu4wX3/X08MsP01baqGKi9GsoAmQ8="
+    "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
+    "bytecodealliance.cachix.org-1:0SBgh//n2n0heh0sDFhTm+ZKBRy2sInakzFGfzN531Y="
+    "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk="
+    "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+  ]
+  ++ optional config.determinate.enable "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM=";
+
   nopasswd = command: {
     inherit command;
     options = [
@@ -126,24 +147,9 @@ in
         users.root.name
       ];
       nix.settings.require-sigs = true;
-      nix.settings.substituters = [
-        "https://rvolosatovs.cachix.org"
-        "https://nixify.cachix.org"
-        "https://cache.nixos.org"
-        "https://bytecodealliance.cachix.org"
-        "https://crane.cachix.org"
-        "https://nix-community.cachix.org"
-      ]
-      ++ optional config.determinate.enable "https://cache.flakehub.com";
-      nix.settings.trusted-public-keys = [
-        "rvolosatovs.cachix.org-1:eRYUO4OXTSmpDFWu4wX3/X08MsP01baqGKi9GsoAmQ8="
-        "nixify.cachix.org-1:95SiUQuf8Ij0hwDweALJsLtnMyv/otZamWNRp1Q1pXw="
-        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-        "bytecodealliance.cachix.org-1:0SBgh//n2n0heh0sDFhTm+ZKBRy2sInakzFGfzN531Y="
-        "crane.cachix.org-1:8Scfpmn9w+hGdXH/Q9tTLiYAE/2dnJYRJP7kl80GuRk="
-        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      ]
-      ++ optional config.determinate.enable "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM=";
+      nix.settings.substituters = substituters;
+      nix.settings.trusted-public-keys = trusted-public-keys;
+      nix.settings.trusted-substituters = substituters;
       nix.settings.trusted-users = with config.users; [
         "@${groups.wheel.name}"
         users.owner.name


### PR DESCRIPTION
Factor substituters and trusted-public-keys into shared let bindings in both the NixOS and Darwin modules, and populate trusted-substituters from the full substituter list on both (previously NixOS only trusted the FlakeHub cache).

Add install.determinate.systems to both modules and drop the redundant cache.nixos.org entry on NixOS (it is a NixOS default); Darwin keeps it explicit since nix-darwin only adds it with the linux-builder VM.