### PR TITLE
feat(scripts): add gh-merge-dependabot

### DIFF
--- a/homeModules/nixelium.nix
+++ b/homeModules/nixelium.nix
@@ -245,6 +245,7 @@ in
         pkgs.fd
         pkgs.file
         pkgs.findutils
+        pkgs.gh-merge-dependabot
         pkgs.git-rebase-all
         pkgs.gnumake
         pkgs.jq

--- a/overlays/scripts.nix
+++ b/overlays/scripts.nix
@@ -15,6 +15,62 @@ let
 
       ${pkgs.git}/bin/git checkout -q "''${base}" && ${pkgs.git}/bin/git branch --merged | grep -v '\*' | ${pkgs.findutils}/bin/xargs -r ${pkgs.git}/bin/git branch -d
     '';
+
+    gh-merge-dependabot = pkgs.writeShellScriptBin "gh-merge-dependabot" ''
+      set -euo pipefail
+
+      repo="''${1:-$(${pkgs.gh}/bin/gh repo view --json nameWithOwner -q .nameWithOwner)}"
+      owner="''${repo%%/*}"
+      name="''${repo#*/}"
+
+      me="$(${pkgs.gh}/bin/gh api user --jq .login)"
+
+      ${pkgs.gh}/bin/gh api graphql \
+        -f owner="$owner" \
+        -f name="$name" \
+        -f query='
+          query($owner: String!, $name: String!) {
+            repository(owner: $owner, name: $name) {
+              pullRequests(states: OPEN, first: 100) {
+                nodes {
+                  number
+                  url
+                  isInMergeQueue
+                  author { login }
+                  latestReviews(first: 100) {
+                    nodes {
+                      state
+                      author { login }
+                    }
+                  }
+                }
+              }
+            }
+          }' |
+        ${pkgs.jq}/bin/jq -r --arg me "$me" '
+          .data.repository.pullRequests.nodes[]
+          | select(.author.login == "dependabot")
+          | select(.isInMergeQueue | not)
+          | [
+              .number,
+              .url,
+              any(.latestReviews.nodes[]; .author.login == $me and .state == "APPROVED")
+            ]
+          | @tsv' |
+      while IFS=$'\t' read -r number url approved; do
+        if [ "$approved" = "true" ]; then
+          echo "PR #$number ($url) already approved, enabling auto-merge"
+        else
+          echo "Approving and auto-merging PR #$number ($url)"
+          if ! ${pkgs.gh}/bin/gh pr review --repo "$repo" --approve "$number"; then
+            echo "Skipping PR #$number: could not approve" >&2
+          fi
+        fi
+        if ! ${pkgs.gh}/bin/gh pr merge --repo "$repo" --auto "$number"; then
+          echo "Skipping PR #$number: could not enable auto-merge" >&2
+        fi
+      done
+    '';
   };
 in
 final: prev: scripts final prev

--- a/overlays/scripts.nix
+++ b/overlays/scripts.nix
@@ -19,7 +19,16 @@ let
     gh-merge-dependabot = pkgs.writeShellScriptBin "gh-merge-dependabot" ''
       set -euo pipefail
 
-      repo="''${1:-$(${pkgs.gh}/bin/gh repo view --json nameWithOwner -q .nameWithOwner)}"
+      merge_method=()
+      repo=""
+      for arg in "$@"; do
+        case "$arg" in
+          --merge | --rebase | --squash) merge_method=("$arg") ;;
+          *) repo="$arg" ;;
+        esac
+      done
+
+      repo="''${repo:-$(${pkgs.gh}/bin/gh repo view --json nameWithOwner -q .nameWithOwner)}"
       owner="''${repo%%/*}"
       name="''${repo#*/}"
 
@@ -66,7 +75,7 @@ let
             echo "Skipping PR #$number: could not approve" >&2
           fi
         fi
-        if ! ${pkgs.gh}/bin/gh pr merge --repo "$repo" --auto "$number"; then
+        if ! ${pkgs.gh}/bin/gh pr merge --repo "$repo" --auto "''${merge_method[@]}" "$number"; then
           echo "Skipping PR #$number: could not enable auto-merge" >&2
         fi
       done


### PR DESCRIPTION
Integrates the `approve-and-auto-merge-dependabot.sh` script from `bytecodealliance/wrpc` into this repo as a `gh-merge-dependabot` command, following the `git-rebase-all` pattern.

## Changes
- `overlays/scripts.nix` — new `gh-merge-dependabot` `writeShellScriptBin`; `gh`/`jq` referenced via Nix store paths.
- `homeModules/nixelium.nix` — added `pkgs.gh-merge-dependabot` to `home.packages`.

## Behavior
Approves and enables auto-merge for all open Dependabot PRs in a repo. Unlike the original (which hardcoded `bytecodealliance/wrpc`), the repo defaults to the current repo via `gh repo view --json nameWithOwner`; override with `gh-merge-dependabot owner/repo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)