### PR TITLE
feat(darwin): install Claude Desktop (Cowork) via homebrew cask

### DIFF
--- a/darwinModules/nixelium.nix
+++ b/darwinModules/nixelium.nix
@@ -91,6 +91,10 @@ in
           name = "chromium";
           args.require_sha = false;
         }
+        {
+          name = "claude";
+          args.require_sha = false;
+        }
         "firefox" # TODO: switch to nixpkgs
         "lm-studio" # TODO: switch to nixpkgs (currently broken: aarch64-darwin stable marked broken, unstable fails on codesign --deep)
         "mac-mouse-fix"


### PR DESCRIPTION
Adds the `claude` Homebrew cask to the `iridium` (Darwin) config, which installs the Claude Desktop app — the host for **Cowork** (macOS Apple Silicon only).

## Details
- The `claude` cask uses `version :latest` + `sha256 :no_check` (the app auto-updates), so it sets `args.require_sha = false`, matching the existing `chromium`/`steam` entries.
- Placed alphabetically after `chromium`.

## Testing
- `nix fmt` — clean
- `nix build -L .#darwinConfigurations.iridium.system` — builds
- Verified `cask "claude"` appears in the generated Brewfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)