### PR TITLE
aarch64-vm-nixvm: bump root disk 128G -> 256G

### DIFF
--- a/nixosConfigurations/aarch64-vm-nixvm/default.nix
+++ b/nixosConfigurations/aarch64-vm-nixvm/default.nix
@@ -22,7 +22,7 @@ nixpkgs-nixos.lib.nixosSystem {
 
         home-manager.users.owner.nixelium.profile.unrestricted-ai.enable = true;
 
-        nixvm.guest.rootSize = "128G";
+        nixvm.guest.rootSize = "256G";
 
         # Raise the /nix/store overlay's writable-tmpfs cap and back it with
         # swap. nixvm.nixosModules.guest mounts the overlay's upper/work on a


### PR DESCRIPTION
The guest root partition was regularly filling up (74% of 128G) during long agent sessions with large cross-compile/build trees. Double the single-partition image cap; the raw image is sparse, so the host only pays for blocks actually written.