### PR TITLE
codex: trust the launch directory in the unrestricted-ai profile

### DIFF
--- a/homeModules/nixelium.nix
+++ b/homeModules/nixelium.nix
@@ -405,7 +405,6 @@ in
         ${readFile ../agents/policy.md}
         ${optionalString cfg.profile.unrestricted-ai.enable (readFile ../agents/vm-workflow.md)}
       '';
-      programs.codex.package = pkgs.codex;
 
       programs.delta.enable = true;
       programs.delta.enableGitIntegration = true;
@@ -1374,11 +1373,11 @@ in
     (mkIf cfg.profile.unrestricted-ai.enable {
       home.shellAliases.agy = "agy --dangerously-skip-permissions";
 
-
       programs.claude-code.settings.env.CLAUDE_CODE_SANDBOXED = "1";
       programs.claude-code.settings.permissions.defaultMode = "bypassPermissions";
       programs.claude-code.settings.skipDangerousModePermissionPrompt = true;
 
+      programs.codex.package = pkgs.codex-trusted;
       programs.codex.settings.approval_policy = "never";
       programs.codex.settings.features.hooks = true;
       programs.codex.settings.model = "gpt-5.6-sol";

--- a/overlays/codex.nix
+++ b/overlays/codex.nix
@@ -1,0 +1,20 @@
+_: final: prev:
+let
+  # `codex` that marks the project it is launched in as trusted, skipping the
+  # trust prompt that can't be persisted anyway because ~/.codex/config.toml is
+  # a read-only store symlink.
+  codex = final.writeShellScript "codex" ''
+    root=$(${final.git}/bin/git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+    exec ${final.codex}/bin/codex -c "projects={'$root'={trust_level='trusted'}}" "$@"
+  '';
+in
+{
+  codex-trusted = final.symlinkJoin {
+    name = "codex-trusted-${final.codex.version}";
+    inherit (final.codex) meta version;
+    paths = [ final.codex ];
+    postBuild = ''
+      ln -sf ${codex} $out/bin/codex
+    '';
+  };
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -20,6 +20,7 @@ let
       inherit overlays;
     };
 
+  codex = import ./codex.nix inputs;
   images = import ./images.nix inputs;
   infrastructure = import ./infrastructure.nix inputs;
   install = import ./install.nix inputs;
@@ -88,6 +89,7 @@ let
 in
 {
   inherit
+    codex
     firefox
     gopass
     images
@@ -128,5 +130,7 @@ in
 
     claude-code-nix.overlays.default
     codex-cli-nix.overlays.default
+
+    codex
   ];
 }


### PR DESCRIPTION
Codex now shows "Do you trust the contents of this directory?" whenever the active project has no `projects.<path>.trust_level` entry, and the answer can't be persisted because ~/.codex/config.toml is a read-only store symlink. Trust is keyed by exact project root with no parent inheritance (openai/codex#19426), so the per-VM entries don't cover new checkouts.

Add a `codex-trusted` package wrapping `codex` so it passes the git checkout (or the working directory) as a trusted project via `-c projects={...}`; the inline-table form is used because `-c` splits dotted keys on every ".". Use it as programs.codex.package under the unrestricted-ai profile, and drop the explicit
`programs.codex.package = pkgs.codex`, which just restated the module default.

Inspired by https://github.com/samestep/env/pull/86.