### PR TITLE
ci: revive nix-flake-update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,3 @@ updates:
   directory: "/.github/actions/install-nix"
   schedule:
     interval: "daily"
-- package-ecosystem: "nix"
-  directory: "/"
-  open-pull-requests-limit: 30
-  schedule:
-    interval: "daily"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,13 +7,10 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'rvolosatovs-bot[bot]'
     runs-on: ubuntu-latest
     steps:
-    - id: meta
-      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-    - if: steps.meta.outputs.package-ecosystem == 'nix'
-      run: gh pr merge --auto --rebase "$PR_URL"
+    - run: gh pr merge --auto --rebase "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,20 @@
+name: nix-flake-update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  nix-flake-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rvolosatovs/nix-flake-update-action@c70e051a34b86ff68658f2365c3c3db269db2e39 # v3.0.1
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          assignees: rvolosatovs
+          reviewers: rvolosatovs
+          delete-branch: true
+          signoff: true
+          labels: dependencies


### PR DESCRIPTION
Dependabot's nix ecosystem support has proven inadequate; switch back to rvolosatovs/nix-flake-update-action for flake input updates and leave dependabot handling GitHub Actions only.